### PR TITLE
Shutting down compactionExecutor on db close

### DIFF
--- a/src/main/java/com/jordanwilliams/heftydb/compact/Compactor.java
+++ b/src/main/java/com/jordanwilliams/heftydb/compact/Compactor.java
@@ -215,6 +215,7 @@ public class Compactor {
     }
 
     public void close() throws IOException {
+        compactionExecutor.shutdownNow();
         compactionTaskExecutor.shutdownNow();
     }
 


### PR DESCRIPTION
Hi,

Thank you for this awesome project!
Noticed that my process wasn't finishing even after db.close(). 
Shutting down the compaction executor seems to help.

Best,
